### PR TITLE
feat: adds the possibility to remove duplicated footnotes, but still refer to the footnote number of the original text

### DIFF
--- a/_extensions/quarto-plus/_extension.yml
+++ b/_extensions/quarto-plus/_extension.yml
@@ -1,6 +1,6 @@
 title: Quarto-Plus
 author: Jacob Dumbleton
-version: 0.2.0
+version: 0.3.0
 quarto-required: ">=1.6.36"
 contributes:
   shortcodes:
@@ -10,3 +10,4 @@ contributes:
     - header.lua
     - table_of_contents.lua
     - terms_and_abbreviations.lua
+    - dedup-footnotes.lua

--- a/_extensions/quarto-plus/dedup-footnotes.lua
+++ b/_extensions/quarto-plus/dedup-footnotes.lua
@@ -1,0 +1,48 @@
+local dedup_footnotes = true
+local footnote_style = "Footnote Reference"
+
+local seen_notes = {}
+local counter = 0
+
+local function note_to_string(note)
+  return pandoc.utils.stringify(note.content)
+end
+
+return {
+  {
+    Meta = function(meta)
+
+      if meta["dedup-footnotes"] ~= nil then
+        dedup_footnotes =
+          pandoc.utils.stringify(meta["dedup-footnotes"]) == "true"
+      end
+
+      if meta["dedup-footnotes-style"] ~= nil then
+        footnote_style =
+          pandoc.utils.stringify(meta["dedup-footnotes-style"])
+      end
+    end
+  },
+
+  {
+    Note = function(el)
+
+      if not dedup_footnotes then
+        return el
+      end
+
+      local key = note_to_string(el)
+
+      if not seen_notes[key] then
+        counter = counter + 1
+        seen_notes[key] = counter
+        return el
+      end
+
+      return pandoc.Span(
+        pandoc.Superscript({ pandoc.Str(tostring(seen_notes[key])) }),
+        pandoc.Attr("", {}, {{"custom-style", footnote_style}})
+      )
+    end
+  }
+}


### PR DESCRIPTION
Bump extension version to 0.3.0 and register a new dedup-footnotes.lua filter. The filter deduplicates identical footnotes (keeps first instance, replaces duplicates with a superscript reference to the original) and supports metadata options: `dedup-footnotes` (true/false) and `dedup-footnotes-style` (custom style name).